### PR TITLE
Update readme to reflect currently supported node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Useful for unit tests of PDFs
 
-Supports nodejs v10, v12, v14, and v16.
+Supports nodejs v14, v16, v18 and v19.
 
 ## Install
 


### PR DESCRIPTION
The new release `2.0.0` https://github.com/k-yle/pdf-to-img/commit/63ec0345b63b754fc6b81c667e4607bbe3bf7aa9 dropped support for node v10 and v12, while introducing support for v18 and v19. This PR makes the readme reflect the current state.

