### PR TITLE
add pdfjs path for cMapUrl and standardFontDataUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2.1.0 (2022-12-11)
+
+- Fix issue where some standard fonts weren't being loaded
+
 ## 2.0.0 (2022-11-05)
 
 - Support NodeJS v18 and v19

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-to-img",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-to-img",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "canvas": "2.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-to-img",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Kyle Hensel",
   "description": "📃📸 Converts PDFs to images in nodejs with no native dependencies",
   "main": "dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,12 @@ import "./polyfill"; // do this before pdfjs
 // 🛑 inspite of esModuleInterop being on, you still need to use `import *`, and there are no typedefs
 import * as _pdfjs from "pdfjs-dist/legacy/build/pdf";
 import type { DocumentInitParameters } from "pdfjs-dist/types/src/display/api";
+import path from "path";
 import { NodeCanvasFactory } from "./canvasFactory";
 import { parseInput } from "./parseInput";
-import path from "path";
 
 const pdfjs: typeof import("pdfjs-dist") = _pdfjs;
-const pdfjs_path = path.dirname(require.resolve("pdfjs-dist/package.json"));
+const pdfjsPath = path.dirname(require.resolve("pdfjs-dist/package.json"));
 
 /** required since k-yle/pdf-to-img#58, the objects from pdfjs are weirdly structured */
 const sanitize = (x: object) => {
@@ -80,8 +80,8 @@ export async function pdf(
 
   const pdfDocument = await pdfjs.getDocument({
     password: options.password, // retain for backward compatibility, but ensure settings from docInitParams overrides this and others, if given.
-    standardFontDataUrl: path.join(pdfjs_path, "standard_fonts"),
-    cMapUrl: path.join(pdfjs_path, "cmaps"),
+    standardFontDataUrl: path.join(pdfjsPath, "standard_fonts"),
+    cMapUrl: path.join(pdfjsPath, "cmaps"),
     cMapPacked: true,
     ...docInitParams,
     data,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,10 @@ import * as _pdfjs from "pdfjs-dist/legacy/build/pdf";
 import type { DocumentInitParameters } from "pdfjs-dist/types/src/display/api";
 import { NodeCanvasFactory } from "./canvasFactory";
 import { parseInput } from "./parseInput";
+import path from "path";
 
 const pdfjs: typeof import("pdfjs-dist") = _pdfjs;
+const pdfjs_path = path.dirname(require.resolve("pdfjs-dist/package.json"));
 
 /** required since k-yle/pdf-to-img#58, the objects from pdfjs are weirdly structured */
 const sanitize = (x: object) => {
@@ -78,7 +80,8 @@ export async function pdf(
 
   const pdfDocument = await pdfjs.getDocument({
     password: options.password, // retain for backward compatibility, but ensure settings from docInitParams overrides this and others, if given.
-    cMapUrl: "../node_modules/pdfjs-dist/cmaps/", // TODO: this feels hacky
+    standardFontDataUrl: path.join(pdfjs_path, "standard_fonts"),
+    cMapUrl: path.join(pdfjs_path, "cmaps"),
     cMapPacked: true,
     ...docInitParams,
     data,


### PR DESCRIPTION
I was trying to convert a PDF, when I got some warnings about fonts not found.
You can reproduce the behavior with this PDF: [pdf](https://www.raspberrypi.org/app/uploads/2012/04/Raspberry-Pi-Schematics-R1.0.pdf)
```
Warning: fetchStandardFontData: failed to fetch file "FoxitSans.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".
Warning: getPathGenerator - ignoring character: "Error: Requesting object that isn't resolved yet Helvetica_path_U.".
Warning: getPathGenerator - ignoring character: "Error: Requesting object that isn't resolved yet Helvetica_path_S.".
Warning: getPathGenerator - ignoring character: "Error: Requesting object that isn't resolved yet Helvetica_path_B.".
...
Warning: getPathGenerator - ignoring character: "Error: Requesting object that isn't resolved yet Helvetica_path_/.".
```
It is an issue with pdfjs dependency: the module comes with a standard fonts directory, but its path has to be passed explicitly in the `pdfjs.getDocument` options object, by the `standardFontDataUrl` parameter.
So I have added this parameter using `require.resolve` to automatically get the pdfjs module path, and I also used this to fix the path used for `cMapUrl`.