### PR TITLE
fix paths with trailing separator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,8 +80,8 @@ export async function pdf(
 
   const pdfDocument = await pdfjs.getDocument({
     password: options.password, // retain for backward compatibility, but ensure settings from docInitParams overrides this and others, if given.
-    standardFontDataUrl: path.join(pdfjsPath, "standard_fonts"),
-    cMapUrl: path.join(pdfjsPath, "cmaps"),
+    standardFontDataUrl: path.join(pdfjsPath, `standard_fonts${path.sep}`),
+    cMapUrl: path.join(pdfjsPath, `cmaps${path.sep}`),
     cMapPacked: true,
     ...docInitParams,
     data,


### PR DESCRIPTION
Hi, I am sorry because my last fix in #194 was not enough, I checked with the new 2.1.0 release and the bug is still present, the fact is that pdfjs doesn't use `path.join` to build the paths, so the trailing path separator at the end has to be added manually.