### PR TITLE
fixed handling of file path for CLI executions

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -3,7 +3,7 @@
 // @ts-check
 import { promises as fs } from "node:fs";
 import { parseArgs } from "node:util";
-import { join } from "node:path";
+import { join, basename, resolve } from "node:path";
 import { pdf } from "../dist/index.js";
 
 const { values, positionals } = parseArgs({
@@ -25,10 +25,10 @@ if (!inputFile) {
 
 /** the name of the file, without the file extension */
 const inputFileBaseName = /** @type {string} */ (
-  inputFile.split("/").at(-1)
+  basename(inputFile)
 ).replace(/\.pdf$/, "");
 
-const fullInputFilePath = join(process.cwd(), inputFile);
+const fullInputFilePath = resolve(process.cwd(), inputFile);
 const outputFolder = join(process.cwd(), values.output || "");
 
 async function main() {


### PR DESCRIPTION
following scenarios did not work:
- absolute file path to PDF file
- Windows file path to PDF file (because it contains backslashes instead of slashes)