### PR TITLE
Handle CLI help and version flags

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -6,6 +6,31 @@ import { parseArgs } from "node:util";
 import { basename, join, resolve } from "node:path";
 import { pdf } from "../dist/index.js";
 
+const usage = `Usage: pdf2img [options] <input.pdf>
+
+Options:
+  -s, --scale <scale>        output scale (default: 3)
+  -p, --password <password>  password for encrypted PDFs
+  -o, --output <folder>      output folder
+  -g, --pages <pages>        page numbers to render, comma-separated or repeated
+  -v, --version              print version
+  -h, --help                 print help`;
+
+const args = process.argv.slice(2);
+
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(usage);
+  process.exit(0);
+}
+
+if (args.includes("--version") || args.includes("-v")) {
+  const packageJson = JSON.parse(
+    await fs.readFile(new URL("../package.json", import.meta.url), "utf8")
+  );
+  console.log(packageJson.version);
+  process.exit(0);
+}
+
 const { values, positionals } = parseArgs({
   options: {
     scale: { short: "s", type: "string", default: "3" },

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -14,22 +14,9 @@ Options:
   -o, --output <folder>      output folder
   -g, --pages <pages>        page numbers to render, comma-separated or repeated
   -v, --version              print version
-  -h, --help                 print help`;
+  -h, --help                 print help
 
-const args = process.argv.slice(2);
-
-if (args.includes("--help") || args.includes("-h")) {
-  console.log(usage);
-  process.exit(0);
-}
-
-if (args.includes("--version") || args.includes("-v")) {
-  const packageJson = JSON.parse(
-    await fs.readFile(new URL("../package.json", import.meta.url), "utf8")
-  );
-  console.log(packageJson.version);
-  process.exit(0);
-}
+`;
 
 const { values, positionals } = parseArgs({
   options: {
@@ -37,9 +24,24 @@ const { values, positionals } = parseArgs({
     password: { short: "p", type: "string" },
     output: { short: "o", type: "string" },
     pages: { short: "g", type: "string", multiple: true },
+    help: { short: "h", type: "boolean" },
+    version: { short: "v", type: "boolean" },
   },
   allowPositionals: true,
 });
+
+if (values.help) {
+  process.stdout.write(usage);
+  process.exit(0);
+}
+
+if (values.version) {
+  const packageJson = JSON.parse(
+    await fs.readFile(new URL("../package.json", import.meta.url), "utf8")
+  );
+  process.stdout.write(`${packageJson.version}\n`);
+  process.exit(0);
+}
 
 const [inputFile] = positionals;
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -15,6 +15,25 @@ const cliPath = join(__dirname, "..", package_.bin.pdf2img);
 const exampleFile = join(__dirname, "7pages.pdf");
 
 describe("CLI", () => {
+  it("prints help", async () => {
+    const { stdout, stderr } = await execAsync(`node ${cliPath} --help`, {
+      cwd,
+    });
+
+    expect(stdout).toContain("Usage: pdf2img [options] <input.pdf>");
+    expect(stdout).toContain("--pages <pages>");
+    expect(stderr).toBe("");
+  });
+
+  it("prints version", async () => {
+    const { stdout, stderr } = await execAsync(`node ${cliPath} --version`, {
+      cwd,
+    });
+
+    expect(stdout.trim()).toBe(package_.version);
+    expect(stderr).toBe("");
+  });
+
   it("works when specific pages are specified", async () => {
     const { stdout, stderr } = await execAsync(
       `node ${cliPath} --pages 1,6,7 ${exampleFile}`,


### PR DESCRIPTION
## Summary

- handle `pdf2img --help` / `-h` before `parseArgs` rejects the flags
- handle `pdf2img --version` / `-v` by reading the package version
- add CLI coverage for both commands

Fixes #270.

## Verification

```sh
npm run build
npx vitest run tests/cli.test.ts --pool=forks
```

I also packed this branch and installed it into a clean temporary npm project:

```sh
npm pack
npm install /path/to/pdf-to-img-6.1.0.tgz
./node_modules/.bin/pdf2img --help
./node_modules/.bin/pdf2img --version
```

Both commands exit 0 after the fix. The currently published `pdf-to-img@6.1.0` throws `ERR_PARSE_ARGS_UNKNOWN_OPTION` for both flags.
